### PR TITLE
Review factory eval

### DIFF
--- a/R/addins.R
+++ b/R/addins.R
@@ -17,28 +17,9 @@ NULL
 addin_factory <- function(addin, body) {
   # get the body as expression from the call
   body <- match.call()$body
-  # alternative implementations
-  # 1. evaluate the expression inside the binding function (lexical scoping)
-  binding.1 <- function() {
+  binding <- function() {
     with_addin_errors(eval(body), addin)
   }
-  # 2. use substitute to get the body of the addin binding same as if manually
-  # created, and use it to construct the binding function
-  # > 2.1. by using function as a function
-  # > > 2.1.1
-  binding.2.1.1 <- eval(call("function", NULL, substitute(
-    with_addin_errors(body, addin))
-  ))
-  # > > 2.1.2
-  binding.2.1.2 <- do.call("function", list(NULL, substitute(
-    with_addin_errors(body, addin))
-  ))
-  # > 2.2. by re-assigning the body
-  binding.2.2 <- function() {}
-  body(binding.2.2) <- substitute(
-    with_addin_errors(body, addin)
-  )
-  binding <- binding.2.1.1
   attr(binding, "addin") <- addin
   binding
 }

--- a/R/addins.R
+++ b/R/addins.R
@@ -15,9 +15,30 @@ NULL
 # the addin name is also added, and used for unit-testing the consistency with
 # addins.dcf.
 addin_factory <- function(addin, body) {
-  binding <- function() {
-    with_addin_errors(addin = addin, body)
+  # get the body as expression from the call
+  body <- match.call()$body
+  # alternative implementations
+  # 1. evaluate the expression inside the binding function (lexical scoping)
+  binding.1 <- function() {
+    with_addin_errors(eval(body), addin)
   }
+  # 2. use substitute to get the body of the addin binding same as if manually
+  # created, and use it to construct the binding function
+  # > 2.1. by using function as a function
+  # > > 2.1.1
+  binding.2.1.1 <- eval(call("function", NULL, substitute(
+    with_addin_errors(body, addin))
+  ))
+  # > > 2.1.2
+  binding.2.1.2 <- do.call("function", list(NULL, substitute(
+    with_addin_errors(body, addin))
+  ))
+  # > 2.2. by re-assigning the body
+  binding.2.2 <- function() {}
+  body(binding.2.2) <- substitute(
+    with_addin_errors(body, addin)
+  )
+  binding <- binding.2.1.1
   attr(binding, "addin") <- addin
   binding
 }

--- a/R/addins.R
+++ b/R/addins.R
@@ -23,15 +23,15 @@ addin_factory <- function(addin, body) {
 }
 addin_other <- addin_factory(
   addin = "Compare with other...",
-  expression(compare_active_file_with_other())
+  compare_active_file_with_other()
 )
 addin_repo <- addin_factory(
   addin = "Compare with repo",
-  expression(compare_active_file_with_repo())
+  compare_active_file_with_repo()
 )
 addin_project <- addin_factory(
   addin = "Compare with repo - project",
-  expression(compare_project_with_repo())
+  compare_project_with_repo()
 )
 
 # Handle addin-specific error messages
@@ -40,7 +40,7 @@ addin_message <- function(addin, condition) {
 }
 with_addin_errors <- function(expr, addin) {
   withCallingHandlers(
-    eval(expr),
+    expr,
     error = function(e) {
       stop(addin_message(addin, e), call. = FALSE)
     }

--- a/tests/testthat/test-addins.R
+++ b/tests/testthat/test-addins.R
@@ -30,6 +30,17 @@ test_that("Addins factory returns a function with customized errors", {
   )
 })
 
+test_that("Addins factory wraps around the expression and not its value", {
+  addin_fun <- addin_factory("My Addin", {
+    message("side-effect in every call")
+    invisible(0)
+  })
+  # if the expression value is (lazily) wrapped around, further calls would not
+  # re-trigger a message
+  expect_message(addin_fun(), "side-effect")
+  expect_message(addin_fun(), "side-effect")
+})
+
 # RStudio addins ----
 context("RStudio addins")
 


### PR DESCRIPTION
See #26.

As part of the PR review, only the desired version of the several alternative implementations (see https://github.com/miraisolutions/compareWith/issues/26#issuecomment-503679034) should be kept and directly assigned as `binding`.