### PR TITLE
Fix xvfb on Travis CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@
 language: R
 cache: packages
 
+services:
+  - xvfb
+
 before_install:
   - sudo apt-get update
   - sudo apt-get install -y meld

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ before_install:
   - sudo apt-get install -y meld
   # Fix GtkWarning: could not open display
   # <https://blog.matthieu.brouillard.fr/2013/09/19/headfull-vs-headless-travis-ci-build/>
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
+  # - "export DISPLAY=:99.0"
+  # - "sh -e /etc/init.d/xvfb start"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,3 @@ services:
 before_install:
   - sudo apt-get update
   - sudo apt-get install -y meld
-  # Fix GtkWarning: could not open display
-  # <https://blog.matthieu.brouillard.fr/2013/09/19/headfull-vs-headless-travis-ci-build/>
-  # - "export DISPLAY=:99.0"
-  # - "sh -e /etc/init.d/xvfb start"


### PR DESCRIPTION
Supported via `services: ` for the latest TravisCI builds

https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui